### PR TITLE
Worked on parallelization.

### DIFF
--- a/central2dBaseClass.h
+++ b/central2dBaseClass.h
@@ -185,7 +185,7 @@ protected:
 
     // Apply limiter to all components in a vector
     #pragma omp declare simd
-    static void limdiff(vec& restrict du, const vec& um, const vec& u0, const vec& up) {
+    static void limdiff(vec& __restrict__ du, const vec& um, const vec& u0, const vec& up) {
       #pragma ivdep
       #pragma vector aligned
       for (int m = 0; m < du.size(); ++m) {


### PR DESCRIPTION
I did some more work on the blocking too. I observed that if we increase the number of blocks to some higher number than `floor(sqrt(omp_get_max_threads()))` the performance keeps increasing for a while. Not much much more though, maybe 25%. I did not change that part because I was not sure what to put, it depends on the size of the grid probably.

I also have scratched a part about dividing the grid into subdomains. 
# Blocking Simulation Grid

After failing to speed up the code by parallelizing inner `for` loops, we decide to split up the regions of the simulation grid and running them in parallel. This way we can do more computation before we syncronize. The original domain is sampled on a square grid and we choose to have square subdomains as well.

To be able to evaluate the subdomains independently, we created two new classes: `SimBlock` and `BlockedSimulation`. `SimBlock` inherits from `Sim` and keeps the functions that run locally. We replace `apply_periodic` with 8 functions that copy the ghost cells from 8 neighbors of the original block. Once we copy the corresponding rows and columns into ghost cells, we can basically run inherited `compute_fg_speeds()`, `limited_derivatives()` or `compute_step()` on every block independently.

`BlockedSimulation` holds a collection of blocks, like an `std::vector<SimBlock>`, and it implements the global functions like the constructor, `run()`, `solution_check()` etc. The `run()` function looks almost the same as original `Sim::run()` but now we can evaluate each block in parallel. The determination of the maximum allowed time step is still a global calculation so we run that in series.

We are given that in between two time steps the dependency of any value on the grid is bounded within its neighborhood. To quantify they are only affected by the points that are 3 units away. This means that 3 ghost cells in each direction is sufficient for taking two time steps before recopying the new values from the neighboring blocks. We unroll the loop that takes different steps for even and odd iterations inside the `run` function. This way we invoke our `copy_ghosts(i, j)` only once at every even time step. We also avoid unnecessary barriers in our parallel flow.
